### PR TITLE
Remove search size dialog

### DIFF
--- a/PS4_Cheater/main.cs
+++ b/PS4_Cheater/main.cs
@@ -277,11 +277,6 @@
             {
                 if (new_scan_btn.Text == CONSTANT.FIRST_SCAN)
                 {
-                    if (MessageBox.Show("search size:" + (processManager.MappedSectionList.TotalMemorySize / 1024).ToString() + "KB") != DialogResult.OK)
-                    {
-                        return;
-                    }
-
                     memoryHelper.InitMemoryHandler((string)valueTypeList.SelectedItem,
                         (string)compareTypeList.SelectedItem, alignment_box.Checked, value_box.Text.Length);
 


### PR DESCRIPTION
you're going to scan regardless of what size... only slows down the whole process.